### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ Returns a stream with the concatenated asset files from the build blocks inside 
 Brings back the previously filtered out HTML files.
 
 
+## NOTES
+
+[ClosureCompiler.js](https://github.com/dcodeIO/ClosureCompiler.js) doesn't support Buffers, which means if you want to use [gulp-closure-compiler](https://github.com/sindresorhus/gulp-closure-compiler) you'll have to first write out the `combined.js` to disk. See [this](https://github.com/dcodeIO/ClosureCompiler.js/issues/11) for more information.
+
+
 ## License
 
 MIT © [Jonathan Kemp](http://jonkemp.com)


### PR DESCRIPTION
I just spent several hours trying to figure out why my gulp-useref setup wasn't working - until I finally came across this: https://github.com/dcodeIO/ClosureCompiler.js/issues/11

It might help other folks if you include this warning in the README.

Thanks for this fantastic plugin - the gulp-filter integration is pretty clever.
