### PR TITLE
Fixes #6.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ var stream = function () {
 };
 
 stream.restore = function () {
-    return restoreStream;
+    return restoreStream.pipe(through.obj(), { end: false });
 };
 
 module.exports = stream;


### PR DESCRIPTION
Keep the stream alive to avoid `Error: write after end`.
