### PR TITLE
add searchPath option to useref.assets()

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ The resulting HTML would be:
 
 ## API
 
-### useref.assets()
+### useref.assets(options)
 
-Returns a stream with the concatenated asset files from the build blocks inside the HTML.
+Returns a stream with the concatenated asset files from the build blocks inside the HTML. Available options:
+
+- `searchPath` - Specify the location to search for javascript/css files, relative to the current working directory. Can be a string or array of strings.
 
 
 ### useref.restore()

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ module.exports = function () {
     });
 };
 
-module.exports.assets = function () {
+module.exports.assets = function (options) {
+    var opts = options || {};
+
     return through.obj(function (file, enc, cb) {
         var output = useref(file.contents.toString());
         var assets = output[1];
@@ -45,6 +47,14 @@ module.exports.assets = function () {
                     var searchPaths;
                     if (files[name].searchPaths) {
                         searchPaths = path.join(file.cwd, files[name].searchPaths);
+                    } else if (opts.searchPath) {
+                        if (Array.isArray(opts.searchPath)) {
+                            var pathString = '{'+opts.searchPath.join(',')+'}';
+                        } else {
+                            var pathString = opts.searchPath;
+                        }
+
+                        searchPaths = path.join(file.cwd, pathString);
                     }
 
                     filepaths.forEach(function (filepath) {

--- a/test/fixtures/07.html
+++ b/test/fixtures/07.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<!-- build:css /css/combined.css -->
+<link href="/css/one.css" rel="stylesheet">
+<link href="/css/two.css" rel="stylesheet">
+<!-- endbuild -->
+</head>
+<body>
+<!-- build:js scripts/combined.js -->
+<script type="text/javascript" src="scripts/this.js"></script>
+<script type="text/javascript" src="scripts/that.js"></script>
+<!-- endbuild -->
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -157,6 +157,36 @@ describe('useref.assets()', function() {
 
         stream.end();
     });
+
+    it('should handle an alternate default search path', function(done) {
+        var a = 0;
+
+        var testFile = getFixture('07.html');
+
+        var stream = useref.assets({
+            searchPath: '.tmp'
+        });
+
+        stream.on('data', function(newFile){
+            should.exist(newFile.contents);
+            if (a == 1) {
+                newFile.path.should.equal(path.normalize('./test/fixtures/scripts/combined.js'));
+            }
+            else if (a == 2) {
+                newFile.path.should.equal(path.normalize('./test/fixtures/css/combined.css'));
+            }
+            ++a;
+        });
+
+        stream.once('end', function () {
+            a.should.equal(2);
+            done();
+        });
+
+        stream.write(testFile);
+
+        stream.end();
+    });
 });
 
 describe('useref.restore()', function() {


### PR DESCRIPTION
This makes it possible to specify a searchPath for your uncompiled assets from the gulpfile as well as from the build blocks - related to issue #8.

My use case is compiling coffeescript to the public directory of my webserver for development, and then using gulp-useref to concatenate it for production.
