### PR TITLE
Added an option to store original sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ var glob = require('glob');
 
 var restoreStream = through.obj();
 
-module.exports = function() {
-    return through.obj(function(file, enc, cb) {
+module.exports = function () {
+    return through.obj(function (file, enc, cb) {
         if (file.isStream()) {
             this.emit('error', new gutil.PluginError('gulp-useref', 'Streaming not supported'));
             return cb();
@@ -30,17 +30,17 @@ module.exports = function() {
     });
 };
 
-module.exports.assets = function(options) {
+module.exports.assets = function (options) {
     var opts = options || {};
 
-    return through.obj(function(file, enc, cb) {
+    return through.obj(function (file, enc, cb) {
         var output = useref(file.contents.toString());
         var assets = output[1];
 
-        ['css', 'js'].forEach(function(type) {
+        ['css', 'js'].forEach(function (type) {
             var files = assets[type];
             if (files) {
-                Object.keys(files).forEach(function(name) {
+                Object.keys(files).forEach(function (name) {
                     var buffer = [];
                     var filepaths = files[name].assets;
 
@@ -59,7 +59,7 @@ module.exports.assets = function(options) {
                         }
 
                         var joinedFilePaths = [];
-                        filepaths.forEach(function(filepath) {
+                        filepaths.forEach(function (filepath) {
                             var pattern = path.join((searchPaths || file.base), filepath);
                             var filenames = glob.sync(pattern);
                             if (!filenames.length) {
@@ -99,6 +99,6 @@ module.exports.assets = function(options) {
     });
 };
 
-module.exports.restore = function() {
+module.exports.restore = function () {
     return restoreStream.pipe(through.obj(), { end: false });
 };


### PR DESCRIPTION
Added a new option `storeOriginalSources` that saves original sources of the concatenated file to a new `userefSources` property. It can then be used to exclude those files from other processing.
