### PR TITLE
Expose types as options: only concatenate selective types

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,12 +32,13 @@ module.exports = function () {
 
 module.exports.assets = function (options) {
     var opts = options || {};
+    var types = opts.types || ['css', 'js'];
 
     return through.obj(function (file, enc, cb) {
         var output = useref(file.contents.toString());
         var assets = output[1];
 
-        ['css', 'js'].forEach(function (type) {
+        types.forEach(function (type) {
             var files = assets[type];
             if (files) {
                 Object.keys(files).forEach(function (name) {


### PR DESCRIPTION
This will expose optional types for concatenation.
if  `types` are not specified, it will concatenate both `css` and `js` as before.

``` js
gulp.task('html', function () {
    return gulp.src('app/*.html')
        .pipe($.useref.assets({searchPath: '{.tmp,app}', types: ['css']}))
        .pipe(gulpif('*.js', uglify()))
        .pipe(gulpif('*.css', minifyCss()))
        .pipe(useref.restore())
        .pipe(useref())
        .pipe(gulp.dest('dist'));
});
```

Above task only concatenate `css` files. 
