### PR TITLE
more clear error message when file not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,11 +79,7 @@ module.exports.assets = function (options) {
                                 try {
                                     buffer.push(stripBom(fs.readFileSync(filenames[0])));
                                 } catch (err) {
-                                    if (err.code === 'ENOENT') {
-                                        this.emit('error', 'gulp-useref: no such file or directory \'' + pattern + '\'');
-                                    } else {
-                                        this.emit('error', new gutil.PluginError('gulp-useref', err));
-                                    }
+                                    this.emit('error', new gutil.PluginError('gulp-useref', err));
                                 }
                             }
                         }, this);


### PR DESCRIPTION
when the file is not exist.
the error msg is

```
events.js:87
      throw Error('Uncaught, unspecified "error" event.');
            ^
Error: Uncaught, unspecified "error" event.
    at Error (native)
    at Transform.EventEmitter.emit (events.js:87:13)
```

it's hard to read.

after this change, the message is

```
events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: ENOENT, no such file or directory '...'

```
