### PR TITLE
Introduce brace-expand-join

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ module.exports = function () {
 module.exports.assets = function (options) {
     var path = require('path'),
         fs = require('fs'),
+        braceExpandJoin = require('brace-expand-join'),
         glob = require('glob'),
         stripBom = require('strip-bom'),
         isAbsoluteUrl = require('is-absolute-url'),
@@ -51,7 +52,7 @@ module.exports.assets = function (options) {
                             joinedFile;
 
                         if (files[name].searchPaths) {
-                            searchPaths = path.join(file.cwd, files[name].searchPaths);
+                            searchPaths = braceExpandJoin(file.cwd, files[name].searchPaths);
                         } else if (opts.searchPath) {
                             if (Array.isArray(opts.searchPath)) {
                                 if (opts.searchPath.length > 1) {
@@ -63,7 +64,7 @@ module.exports.assets = function (options) {
                                 searchPaths = opts.searchPath;
                             }
 
-                            searchPaths = path.join(file.cwd, searchPaths);
+                            searchPaths = braceExpandJoin(file.cwd, searchPaths);
                         }
 
                         filepaths.forEach(function (filepath) {
@@ -71,7 +72,7 @@ module.exports.assets = function (options) {
                                 filenames;
 
                             if (!isAbsoluteUrl(filepath)) {
-                                pattern = path.join((searchPaths || file.base), filepath);
+                                pattern = braceExpandJoin((searchPaths || file.base), filepath);
                                 filenames = glob.sync(pattern);
                                 if (!filenames.length) {
                                     filenames.push(pattern);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "dependencies": {
+    "brace-expand-join": "^0.1.0",
     "glob": "^4.0.2",
     "gulp-util": "^3.0.0",
     "is-absolute-url": "^1.0.0",

--- a/test/fixtures/07.html
+++ b/test/fixtures/07.html
@@ -8,7 +8,7 @@
 <body>
 <!-- build:js scripts/main.js -->
 <script type="text/javascript" src="scripts/module1.js"></script>
-<script type="text/javascript" src="scripts/module2.js"></script>
+<script type="text/javascript" src="../.tmp/scripts/module2.js"></script>
 <!-- endbuild -->
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -210,6 +210,34 @@ describe('useref.assets()', function() {
         stream.end();
     });
 
+    it('should get the alternate search paths from options with brace expansion', function(done) {
+        var a = 0;
+
+        var testFile = getFixture('07.html');
+
+        var stream = useref.assets({
+            searchPath: '.{,t{,m}}p,../another/search/path',
+        });
+
+        stream.on('data', function(newFile){
+            should.exist(newFile.contents);
+            if (a === 1) {
+                newFile.path.should.equal(path.normalize('./test/fixtures/scripts/main.js'));
+            } else if (a === 2) {
+                newFile.path.should.equal(path.normalize('./test/fixtures/css/combined.css'));
+            }
+            ++a;
+        });
+
+        stream.once('end', function () {
+            a.should.equal(2);
+            done();
+        });
+
+        stream.write(testFile);
+
+        stream.end();
+    });
 
     it('should handle an alternate search path in multiple build blocks', function(done) {
         var a = 0;


### PR DESCRIPTION
- I added a test case when the value of [`searchPath` option](https://github.com/jonkemp/gulp-useref#optionssearchpath) is an array.
- Currently, gulp-useref fails to embed assets if `src` property or `href` property starts with parent directory reference, such as `../path/to/script.js`. gulp-useref uses [path.join()](http://nodejs.org/api/path.html#path_path_join_path1_path2) to join glob patterns, but it doesn't work correctly.
  
  For example, when `searchPath` option is `{foo,foo/bar}` and `script` tag's `src` property is `../modules/script1.js`, We expect `{,foo}/modules/script1.js` as a search path, but the result is `{foo,foo/modules/script1.js`. Actually, [this repo fails the test in such case](https://travis-ci.org/jonkemp/gulp-useref/builds/34882801#L121).
  
  To fix this problem, I created [brace-expand-join](https://github.com/shinnn/node-brace-expand-join) module. It joins and normalizes glob patterns considreing brace expansion. After adding [brace-expand-join](https://github.com/shinnn/node-brace-expand-join) module, [this repo passes all tests](https://travis-ci.org/jonkemp/gulp-useref/builds/34882904). And brace-expand-join itself is well tested on [*nix](https://travis-ci.org/shinnn/node-brace-expand-join) and [Windows](https://ci.appveyor.com/project/ShinnosukeWatanabe/node-brace-expand-join).
