### PR TITLE
Update strip-bom / Remove gulp-util from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,13 @@
     "gulp-util": "^3.0.0",
     "is-absolute-url": "^1.0.0",
     "node-useref": "^0.3.1",
-    "strip-bom": "^0.3.1",
+    "strip-bom": "^1.0.0",
     "through2": "^0.6.1"
   },
   "devDependencies": {
     "mocha": "*",
     "should": "*",
     "gulp-mocha": "^1.0.0",
-    "gulp-util": "^3.0.0",
     "gulp": "^3.6.1",
     "gulp-jshint": "^1.5.3"
   },


### PR DESCRIPTION
- I updated [strip-bom](https://github.com/sindresorhus/strip-bom) to v1.0.0.
- I removed [gulp-util](https://github.com/gulpjs/gulp-util) from `devDependencies`. [It's already included in `dependencies`.](https://github.com/jonkemp/gulp-useref/blob/93d64577de5dba6e460a029fd0f767668c5f163a/package.json#L12)
