### PR TITLE
don't sort results to make sure the first result is always the expected one

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports.assets = function (options) {
 
                             if (!isAbsoluteUrl(filepath)) {
                                 pattern = braceExpandJoin((searchPaths || file.base), filepath);
-                                filenames = glob.sync(pattern);
+                                filenames = glob.sync(pattern, { nosort: true });
                                 if (!filenames.length) {
                                     filenames.push(pattern);
                                 }


### PR DESCRIPTION
I have two folderes with javascript files. The files in the second folder may override those in the first folder, however it's name is alphabetically later. This patch makes sure the files are returned in the order they are found based on the glob pattern, so that `filenames[0]` is the one expected

e.g. dir contents: 

```
/scripts/tmp.js
/overrides/tmp.js
```

usage:

```
var assets = $.useref.assets({ searchPath: '{overrides,scripts}' });
```

yields `/overrides/tmp.js` _after_ this patch
