### PR TITLE
Add Feature: allow pass stream to each asset files before concat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 var gutil = require('gulp-util'),
     through = require('through2'),
-    useref = require('node-useref');
+    useref = require('node-useref'),
+    vfs = require('vinyl-fs'),
+    concat = require('gulp-concat');
 
 module.exports = function () {
     return through.obj(function (file, enc, cb) {
@@ -25,16 +27,20 @@ module.exports = function () {
     });
 };
 
-module.exports.assets = function (options) {
+module.exports.assets = function () {
     var path = require('path'),
-        fs = require('fs'),
         braceExpandJoin = require('brace-expand-join'),
         glob = require('glob'),
-        stripBom = require('strip-bom'),
         isAbsoluteUrl = require('is-absolute-url'),
-        opts = options || {},
-        types = opts.types || ['css', 'js'],
-        restoreStream = through.obj();
+        prepair = [],
+        opts,
+        types,
+        restoreStream = through.obj(),
+        unprocessed = 0,
+        end = false;
+    Array.prototype.push.apply(prepair, arguments);
+    opts = prepair.shift() || {};
+    types = opts.types || ['css', 'js'];
 
     var assets = through.obj(function (file, enc, cb) {
         var output = useref(file.contents.toString());
@@ -43,13 +49,21 @@ module.exports.assets = function (options) {
         types.forEach(function (type) {
             var files = assets[type];
             if (files) {
+                unprocessed += Object.keys(files).length;
+            }
+        });
+
+        types.forEach(function (type) {
+            var files = assets[type];
+            if (files) {
                 Object.keys(files).forEach(function (name) {
-                    var buffer = [];
                     var filepaths = files[name].assets;
 
-                    if (filepaths.length) {
+                    if (!filepaths.length) {
+                        unprocessed --;
+                    } else {
                         var searchPaths,
-                            joinedFile;
+                            src = [];
 
                         if (files[name].searchPaths) {
                             searchPaths = braceExpandJoin(file.cwd, files[name].searchPaths);
@@ -73,35 +87,41 @@ module.exports.assets = function (options) {
 
                             if (!isAbsoluteUrl(filepath)) {
                                 pattern = braceExpandJoin((searchPaths || file.base), filepath);
-                                filenames = glob.sync(pattern, { nosort: true });
+                                filenames = glob.sync(pattern);
                                 if (!filenames.length) {
                                     filenames.push(pattern);
                                 }
-                                try {
-                                    buffer.push(stripBom(fs.readFileSync(filenames[0])));
-                                } catch (err) {
-                                    this.emit('error', new gutil.PluginError('gulp-useref', err));
-                                }
+                                src.push(filenames[0]);
                             }
                         }, this);
+                        var self = this;
+                        var stream = vfs.src(src, {base: file.base});
+                        prepair.forEach(function(plugin) {
+                            stream.pipe(plugin);
+                        });
 
-                        if (buffer.length) {
-                            joinedFile = new gutil.File({
-                                cwd: file.cwd,
-                                base: file.base,
-                                path: path.join(file.base, name),
-                                contents: new Buffer(buffer.join(gutil.linefeed))
-                            });
-
-                            this.push(joinedFile);
-                        }
+                        stream.pipe(concat(name)).pipe(through.obj(function (joinedFile, enc, callback) {
+                            joinedFile.path = path.join(file.base, name);
+                            joinedFile.cwd = file.cwd;
+                            joinedFile.base = file.base;
+                            self.push(joinedFile);
+                            callback(null, joinedFile);
+                        })).on('finish', function() {
+                            if (--unprocessed == 0 && end) {
+                                self.emit('end');
+                            }
+                        });
                     }
-
                 }, this);
             }
         }, this);
 
         restoreStream.write(file, cb);
+    }, function() {
+        end = true;
+        if (unprocessed == 0) {
+            this.emit('end');
+        }
     });
 
     assets.restore = function () {
@@ -110,3 +130,4 @@ module.exports.assets = function (options) {
 
     return assets;
 };
+

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
   "dependencies": {
     "brace-expand-join": "^0.1.0",
     "glob": "^4.0.2",
+    "gulp-concat": "^2.4.1",
     "gulp-util": "^3.0.0",
     "is-absolute-url": "^1.0.0",
     "node-useref": "^0.3.1",
-    "strip-bom": "^1.0.0",
-    "through2": "^0.6.1"
+    "through2": "^0.6.1",
+    "vinyl-fs": "^0.3.13"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
hello @jonkemp, this patch allow transform assets before concat. now the syntax is like 
`$.useref.assets(opts, streamForEachAssetsBeforeConcat1, streamForEachAssetsBeforeConcat2, ...)`
Now we can allow sourceMaps for assets concat in this way: 

``` javascript
gulp.task('html', ['scripts', 'styles'], function() {
  var assets = $.useref.assets({searchPath: ['.tmp/', 'src/']},
                              $.sourcemaps.init({loadMaps: true, debug: true}));  // for each asset file load and init sourceMap
  return gulp.src('src/*.html')
    .pipe(assets)
    .pipe($.sourcemaps.write('.'))
    .pipe(assets.restore())
    .pipe($.useref())
    .pipe($.revReplace())
    .pipe(gulp.dest('./dist'))
});
```
