### PR TITLE
Update: ignore query part of url to support gulp-rev-append

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -113,8 +113,12 @@ module.exports.assets = function (opts) {
 
                 // Add assets to the stream
                 // If noconcat option is false, concat the files first.
+                if (name.indexOf('?') !== -1){
+                    var shortName = name.slice(0, name.indexOf('?'));
+                }
+
                 src
-                    .pipe(gulpif(!opts.noconcat, concat(name)))
+                    .pipe(gulpif(!opts.noconcat, concat(shortName || name)))
                     .pipe(through.obj(function (newFile, enc, callback) {
                         this.push(newFile);
                         callback();

--- a/test/fixtures/10.html
+++ b/test/fixtures/10.html
@@ -1,7 +1,7 @@
 <html>
 <head></head>
 <body>
-<!-- build:js scripts/combined.js -->
+<!-- build:js scripts/combined.js?hash=@@hash -->
 <script type="text/javascript" src="./scripts/this.js"></script>
 <script type="text/javascript" src="../.tmp/scripts/that.js"></script>
 <!-- endbuild -->


### PR DESCRIPTION
@jonkemp we spoke it someday,
it became critical again after clean-css update
if you have something against block scoped vars
or any I can apply 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jonkemp/gulp-useref/84)
<!-- Reviewable:end -->
