### PR TITLE
Allow lazypipe-s in assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports.assets = function (opts) {
 
                 // If any external streams were included, pipe all files to them first
                 streams.forEach(function (stream) {
-                    src.pipe(stream);
+                    src.pipe(stream());
                 });
 
                 // Add assets to the stream


### PR DESCRIPTION
This properly fixes https://github.com/jonkemp/gulp-useref/issues/64; https://github.com/jonkemp/gulp-useref/issues/96

E.g., now source maps are successfully generated with
```js
var assets = plugins.useref.assets({},
    lazypipe().pipe(plugins.sourcemaps.init, {loadMaps: true}));
  return gulp.src('index.html')
    .pipe(assets)
    .pipe(plugins.if(['**/*.js', '!**/jquery.min.js'],
      plugins.uglify({ie_proof: false})))
    .pipe(plugins.if('*.css', lazypipe()
      .pipe(plugins.shorthand)
      .pipe(plugins.autoprefixer)
      .pipe(plugins.minifyCss,
      {roundingPrecision: -1, keepSpecialComments: 0})()))
    .pipe(plugins.sourcemaps.write('maps'))
    .pipe(assets.restore())
    .pipe(plugins.useref())
    .pipe(plugins.if('*.html', plugins.minifyHtml()))
    .pipe(gulp.dest(dist));
```