### PR TITLE
Add Feature: pass options to useref to enable usage of custom blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function getSearchPaths(cwd, searchPath, filepath) {
     }
 }
 
-module.exports = function () {
+module.exports = function (opts) {
     return through.obj(function (file, enc, cb) {
         if (file.isNull()) {
             cb(null, file);
@@ -27,7 +27,7 @@ module.exports = function () {
             return;
         }
 
-        var output = useref(file.contents.toString());
+        var output = useref(file.contents.toString(), opts);
         var html = output[0];
 
         try {

--- a/test/expected/custom-blocks.html
+++ b/test/expected/custom-blocks.html
@@ -1,0 +1,6 @@
+<html>
+<head></head>
+<body>
+customResult
+</body>
+</html>

--- a/test/fixtures/custom-blocks.html
+++ b/test/fixtures/custom-blocks.html
@@ -1,0 +1,8 @@
+<html>
+<head></head>
+<body>
+<!-- build:custom customResult -->
+someContent
+<!-- endbuild -->
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,23 @@ describe('useref()', function() {
     it('should handle multiple blocks', function(done) {
         compare('04.html', '04.html', done);
     });
+
+    it('should handle custom blocks', function (done) {
+        var stream = useref({
+            custom: function (content, target) {
+                return content === 'someContent' ? target : content;
+            }
+        });
+
+        stream.on('data', function (newFile) {
+            getExpected('custom-blocks.html').contents.toString().should.equal(newFile.contents.toString());
+        });
+
+        stream.on('end', done);
+
+        stream.write(getFixture('custom-blocks.html'));
+        stream.end();
+    });
 });
 
 describe('useref.assets()', function() {
@@ -384,6 +401,17 @@ describe('useref.assets()', function() {
 
         stream.write(testFile);
 
+        stream.end();
+    });
+
+    it('should not explode on custom blocks', function (done) {
+        var stream = useref.assets();
+
+        stream.on('end', function () {
+            done();
+        });
+
+        stream.write(getFixture('custom-blocks.html'));
         stream.end();
     });
 


### PR DESCRIPTION
This is to enable [custom blocks](https://www.npmjs.com/package/node-useref#custom-blocks).

Closes #85

~~Blocked by digisfera/useref#37 (for some reason, the 0.3.10 version of node-useref didn't make it to npm)~~