### PR TITLE
Add TransformPath option

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,9 @@ module.exports.assets = function (opts) {
                 globs = filepaths
                     .filter(isRelativeUrl)
                     .map(function (filepath) {
+                        if (opts.transformPath) {
+                            filepath = opts.transformPath(filepath);
+                        }
                         if (searchPaths.length) {
                             return searchPaths.map(function (searchPath) {
                                 return getSearchPaths(file.cwd, searchPath, filepath);

--- a/test/fixtures/bad-path.html
+++ b/test/fixtures/bad-path.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+  <!-- build:css /css/combined.css -->
+  <link href="//raw.githubusercontent.com/necolas/normalize.css/master/normalize.css" rel="stylesheet">
+  <link href="/rootpath/css/one.css" rel="stylesheet">
+  <!-- endbuild -->
+</head>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -460,6 +460,33 @@ describe('useref.assets()', function() {
 
         stream.end();
     });
+
+    it('should transform paths when transformPath function is set', function(done) {
+        var a = 0;
+
+        var testFile = getFixture('bad-path.html');
+
+        var stream = useref.assets({
+            transformPath : function(filePath) {
+                return filePath.replace('/rootpath','')
+            }
+        });
+
+        stream.on('data', function(newFile){
+            should.exist(newFile.contents);
+            newFile.path.should.equal(path.normalize('./test/fixtures/css/combined.css'));
+            ++a;
+        });
+
+        stream.once('end', function () {
+            a.should.equal(1);
+            done();
+        });
+
+        stream.write(testFile);
+
+        stream.end();
+    });
 });
 
 describe('useref.restore()', function() {


### PR DESCRIPTION
Hi,

This was referenced in #21 but cancelled. We need this functionality in order to transform absolute paths (relative to the host) to paths existing on the filesystem.

We need to serve some resources on a specific path like this : `/my-specific-path/css/my-resource.css` , but on the file system it's not located on `/my-specific-path/` ...

The reason why the path is already absolute here is because we have a two step building, one step to generate development files (not minified) and the second step with `useref` to minify resources (and to put again the `/my-specific-path/` part) . Of course we could duplicate gulp tasks to solve this problem but that would complicate things.

I put one test in my PR but feel free to ask more details.

thanks !

