### PR TITLE
mutate src stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ module.exports.assets = function (opts) {
 
                 // If any external streams were included, pipe all files to them first
                 streams.forEach(function (stream) {
-                    src.pipe(stream());
+                    src = src.pipe(stream(name));
                 });
 
                 // Add assets to the stream


### PR DESCRIPTION
So that in the gulp pipe, developers can inject more virtual files in to `src` without making them real writing them to disk first