### PR TITLE
Add external streams to assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,29 @@ Default: `false`
 
 Skip concatenation and add all assets to the stream instead.
 
+#### options.additionalStreams
+
+Type: `Array<Stream>`
+Default: `none`
+
+Use additional streams as sources of assets. Useful for combining gulp-useref with preprocessing tools. For example, to use with TypeScript:
+
+```javascript
+// create stream of virtual files
+var tsStream = gulp.src("src/**/*.ts")
+        .pipe(ts());
+
+    // pass stream to assets, multiple streams are supported
+    var assets = useref.assets({ additionalStreams: [tsStream] });
+
+    // use gulp-useref normally
+    return gulp.src("src/index.html")
+        .pipe(assets)
+        .pipe(assets.restore())
+        .pipe(useref())
+        .pipe(gulp.dest("dist"));
+```
+
 ### stream.restore()
 
 Brings back the previously filtered out HTML files.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 var gutil = require('gulp-util'),
     through = require('through2'),
     useref = require('node-useref'),
-    path = require('path');
+    path = require('path'),
+    multimatch = require('multimatch');
 
 function getSearchPaths(cwd, searchPath, filepath) {
     // Check for multiple search paths within the array
@@ -48,92 +49,166 @@ module.exports.assets = function (opts) {
         _ = require('lodash'),
         concat = require('gulp-concat'),
         gulpif = require('gulp-if'),
+        es = require('event-stream'),
         types = opts.types || ['css', 'js'],
         isRelativeUrl = require('is-relative-url'),
         vfs = require('vinyl-fs'),
-        streams = Array.prototype.slice.call(arguments, 1),
+        transforms = Array.prototype.slice.call(arguments, 1),
         restoreStream = through.obj(),
         unprocessed = 0,
-        end = false;
+        end = false,
+        additionalFiles = [];
+
+    // If any external streams were included, add matched files to src
+    if (opts.additionalStreams) {
+        if (!Array.isArray(opts.additionalStreams)) {
+            opts.additionalStreams = [opts.additionalStreams];
+        }
+
+        opts.additionalStreams = opts.additionalStreams.map(function (stream) {
+            // filters stream to select needed files
+            return stream
+                .pipe(es.through(function (file) {
+                    additionalFiles.push(file);
+                }));
+        });
+    }
+
+    var waitForAssets;
+    if (opts.additionalStreams) {
+        // If we have additional streams, wait for them to run before continuing
+        waitForAssets = es.merge(opts.additionalStreams).pipe(through.obj());
+    } else {
+        // Else, create a fake stream
+        waitForAssets = through.obj();
+        waitForAssets.emit('finish');
+    }
 
     var assetStream = through.obj(function (file, enc, cb) {
-        var output = useref(file.contents.toString());
-        var assets = output[1];
+        var self = this;
+        waitForAssets.pipe(es.wait(function () {
+            var output = useref(file.contents.toString());
+            var assets = output[1];
 
-        types.forEach(function (type) {
-            var files = assets[type];
+            types.forEach(function (type) {
+                var files = assets[type];
 
-            if (!files) {
-                return;
-            }
-
-            Object.keys(files).forEach(function (name) {
-                var src,
-                    globs,
-                    searchPaths,
-                    filepaths = files[name].assets;
-
-                if (!filepaths.length) {
+                if (!files) {
                     return;
                 }
 
-                unprocessed++;
+                Object.keys(files).forEach(function (name) {
+                    var src,
+                        globs,
+                        searchPaths,
+                        filepaths = files[name].assets;
 
-                searchPaths = files[name].searchPaths || opts.searchPath;
+                    if (!filepaths.length) {
+                        return;
+                    }
 
-                // If searchPaths is not an array, use brace-expansion to expand it into an array
-                if (!Array.isArray(searchPaths)) {
-                    searchPaths = expand(searchPaths);
-                }
+                    unprocessed++;
 
-                // Get relative file paths and join with search paths to send to vinyl-fs
-                globs = filepaths
-                    .filter(isRelativeUrl)
-                    .map(function (filepath) {
-                        if (opts.transformPath) {
-                            filepath = opts.transformPath(filepath);
-                        }
-                        if (searchPaths.length) {
-                            return searchPaths.map(function (searchPath) {
-                                return getSearchPaths(file.cwd, searchPath, filepath);
-                            });
-                        } else {
-                            return path.join(file.base, filepath);
+                    searchPaths = files[name].searchPaths || opts.searchPath;
+
+                    // If searchPaths is not an array, use brace-expansion to expand it into an array
+                    if (!Array.isArray(searchPaths)) {
+                        searchPaths = expand(searchPaths);
+                    }
+
+                    // Get relative file paths and join with search paths to send to vinyl-fs
+                    globs = filepaths
+                        .filter(isRelativeUrl)
+                        .map(function (filepath) {
+                            if (opts.transformPath) {
+                                filepath = opts.transformPath(filepath);
+                            }
+                            if (searchPaths.length) {
+                                return searchPaths.map(function (searchPath) {
+                                    return getSearchPaths(file.cwd, searchPath, filepath);
+                                });
+                            } else {
+                                return path.join(file.base, filepath);
+                            }
+                        });
+
+                    // Flatten nested array before giving it to vinyl-fs
+                    globs = _.flatten(globs, true);
+                    src = vfs.src(globs, {
+                        base: file.base,
+                        nosort: true,
+                        nonull: true
+                    });
+
+                    // add files from external streams
+                    additionalFiles.forEach(function (file) {
+                        // check if file should be included
+                        if (multimatch(file.path, globs).length > 0) {
+                            src.push(file);
                         }
                     });
 
-                // Flatten nested array before giving it to vinyl-fs
-                src = vfs.src(_.flatten(globs, true), {
-                    base: file.base,
-                    nosort: true,
-                    nonull: true
+                    // if we added additional files, reorder the stream
+                    if (additionalFiles.length > 0) {
+                        var sortIndex = {};
+                        var i = 0;
+
+                        // Create a sort index so we don't iterate over the globs for every file
+                        globs.forEach(function (glob) {
+                            sortIndex[glob] = i++;
+                        });
+
+                        var sortedFiles = [];
+                        var unsortedFiles = [];
+                        src = src.pipe(through.obj(function (file, enc, cb) {
+                            var index = sortIndex[file.path];
+                            if (index === undefined) {
+                                unsortedFiles.push(file);
+                            } else {
+                                sortedFiles[index] = file;
+                            }
+                            cb();
+                        }, function (cb) {
+                            sortedFiles.forEach(function (file) {
+                                if (file !== undefined) {
+                                    this.push(file);
+                                }
+                            }, this);
+
+                            unsortedFiles.forEach(function (file) {
+                                this.push(file);
+                            }, this);
+                            cb();
+                        }));
+                    }
+
+                    // If any external transforms were included, pipe all files to them first
+                    transforms.forEach(function (fn) {
+                        src = src.pipe(fn(name));
+                    });
+
+                    // Add assets to the stream
+                    // If noconcat option is false, concat the files first.
+                    src
+                        .pipe(gulpif(!opts.noconcat, concat(name)))
+                        .pipe(through.obj(function (newFile, enc, callback) {
+                            // add file to the asset stream
+                            self.push(newFile);
+                            callback();
+                        }))
+                        .on('finish', function () {
+                            if (--unprocessed === 0 && end) {
+                                // end the asset stream
+                                self.emit('end');
+                            }
+                        });
+
                 });
 
-                // If any external streams were included, pipe all files to them first
-                streams.forEach(function (stream) {
-                    src = src.pipe(stream(name));
-                });
+            });
 
-                // Add assets to the stream
-                // If noconcat option is false, concat the files first.
-                src
-                    .pipe(gulpif(!opts.noconcat, concat(name)))
-                    .pipe(through.obj(function (newFile, enc, callback) {
-                        this.push(newFile);
-                        callback();
-                    }.bind(this)))
-                    .on('finish', function () {
-                        if (--unprocessed === 0 && end) {
-                            this.emit('end');
-                        }
-                    }.bind(this));
-
-            }, this);
-
-        }, this);
-
-        restoreStream.write(file, cb);
-
+            restoreStream.write(file, cb);
+        }));
     }, function () {
         end = true;
         if (unprocessed === 0) {

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   },
   "dependencies": {
     "brace-expansion": "^1.1.0",
+    "event-stream": "^3.3.1",
     "gulp-concat": "^2.5.2",
     "gulp-if": "^1.2.5",
     "gulp-util": "^3.0.1",
     "is-relative-url": "^1.0.0",
     "lodash": "^3.3.1",
+    "multimatch": "^2.0.0",
     "node-useref": "^0.3.1",
     "through2": "^0.6.1",
     "vinyl-fs": "^1.0.0"
@@ -21,6 +23,7 @@
     "gulp": "^3.8.11",
     "gulp-jshint": "^1.9.0",
     "gulp-mocha": "^2.0.0",
+    "gulp-rename": "^1.2.2",
     "mocha": "*",
     "should": "*"
   },

--- a/test/fixtures/11.html
+++ b/test/fixtures/11.html
@@ -1,0 +1,11 @@
+<html>
+<head></head>
+<body>
+<!-- build:js scripts/combined.js -->
+<script src="./scripts/this.js"></script>
+<script src="./scripts/renamedthat.js"></script>
+<script src="./scripts/anotherone.js"></script>
+<script src="./scripts/renamedyet.js"></script>
+<!-- endbuild -->
+</body>
+</html>


### PR DESCRIPTION
First draft of adding external streams to assets. Fixes #75 and #30. I updated an undocumented piece of code that appeared to do a similar job. If this is an acceptable solution, I'll create tests and update the doc.

Sample usage (with typescript):

```javascript
// create stream of virtual files
var tsStream = gulp.src("src/**/*.ts")
        .pipe(ts());

    // pass stream to assets, multiple streams are supported
    var assets = useref.assets({}, tsStream);

    // use gulp-useref normally
    return gulp.src("src/index.html")
        .pipe(assets)
        .pipe(assets.restore())
        .pipe(useref())
        .pipe(gulp.dest("dist"));
```