### PR TITLE
Fix the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,12 @@ var gulp = require('gulp'),
     useref = require('gulp-useref'),
     lazypipe = require('lazypipe');
 
-  return gulp.src('index.html')
-    .pipe(useref({}, lazypipe().pipe(sourcemaps.init, { loadMaps: true })))
-    .pipe(sourcemaps.write('maps'))
-    .pipe(gulp.dest(dist));
+gulp.task('default', function () {
+    return gulp.src('index.html')
+        .pipe(useref({}, lazypipe().pipe(sourcemaps.init, { loadMaps: true })()))
+        .pipe(sourcemaps.write('maps'))
+        .pipe(gulp.dest('dist'));
+});
 ```
 
 ### Options
@@ -173,14 +175,18 @@ Default: `none`
 Use additional streams as sources of assets. Useful for combining gulp-useref with preprocessing tools. For example, to use with TypeScript:
 
 ```javascript
+var ts = require('gulp-typescript');
+
 // create stream of virtual files
 var tsStream = gulp.src('src/**/*.ts')
         .pipe(ts());
 
+gulp.task('default', function () {
     // use gulp-useref normally
     return gulp.src('src/index.html')
         .pipe(useref({ additionalStreams: [tsStream] }))
         .pipe(gulp.dest('dist'));
+});
 ```
 
 #### options.transformPath


### PR DESCRIPTION
- add `gulp.task(...)` when missing
- `useref({}, lazypipe().pipe(...))` should be `useref({}, lazypipe().pipe(...)())` (see lazypipe example [here](https://github.com/gulpjs/gulp/blob/v3.9.0/docs/recipes/sharing-streams-with-stream-factories.md))
- `gulp.dest(dist)` should be `gulp.dest('dist')`
- add missing `var ts = require('gulp-typescript');`

(I've detected these mistakes while updating gulp-useref TypeScript definition: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/6864)