### PR TITLE
Fix globbing issue in searchPath option

### DIFF
--- a/lib/streamManager.js
+++ b/lib/streamManager.js
@@ -31,7 +31,11 @@ var exports = module.exports = (function () {
                 filepath = paths.filepath;
 
             if (searchPath && Array.isArray(searchPath)) {
-                searchPath = '{' + searchPath.join(',') + '}';
+                if (searchPath.length === 1) {
+                    searchPath = searchPath[0];
+                } else {
+                    searchPath = '{' + searchPath.join(',') + '}';
+                }
             }
 
             pattern = getPattern(files, {


### PR DESCRIPTION
Add a length > 1 check before adding curly braces to searchPath

This commit fixes an issue where passing an array contain a single path 
to the searchPath option causes the error "File not found with singular 
glob", due to the curly braces added.