### PR TITLE
Fix for issue #176, useref doesn't process all assets

### DIFF
--- a/lib/streamManager.js
+++ b/lib/streamManager.js
@@ -13,7 +13,7 @@ var exports = module.exports = (function () {
         addHtmlToStream = require('./addHtmlToStream'),
         additionalFiles = [],
         unprocessed = 0,
-        end = false;
+        end = undefined;
 
     return {
         options: {},
@@ -115,7 +115,7 @@ var exports = module.exports = (function () {
                 .on('finish', function () {
                     if (--unprocessed === 0 && end) {
                         // end the asset stream
-                        self.emit('end');
+                        end();
                     }
                 });
         },
@@ -177,15 +177,19 @@ var exports = module.exports = (function () {
             }));
         },
 
-        flushFunction: function () {
-            end = true;
+        flushFunction: function (cb) {
+            end = cb;
             if (unprocessed === 0) {
-                this.emit('end');
+                return cb();
             }
         },
 
         additionalStreams: function () {
             var options = exports.options;
+
+            additionalFiles = [];
+            unprocessed = 0;
+            end = undefined;
 
             // If any external streams were included, add matched files to src
             if (options.additionalStreams) {


### PR DESCRIPTION
Depending on how much buffering was available in the gulp pipe, some assets would not be sent to the stage of the pipe.
Root cause is an error in API usage.  emit('end') was being called directly, instead of calling the transform stream's flush callback function.

Fixes #176 