### PR TITLE
Pass _basePath to useref via options

### DIFF
--- a/lib/streamManager.js
+++ b/lib/streamManager.js
@@ -158,6 +158,7 @@ var exports = module.exports = (function () {
                 return cb(new gutil.PluginError('gulp-useref', 'Streaming not supported'));
             }
 
+            options._basePath = _basePath
             output = useref(file.contents.toString(), options);
 
             addHtmlToStream.call(self, file, output[0]);


### PR DESCRIPTION
I need gulp-useref to pass the _basePath variable that it uses in vfs.glob base to useref, so that I have access to it from within my custom block handler, so that I can push files to the stream and they will be output identically to useref internal block handlers.

```javascript
import: function importer (content, target, options, alternateSearchPath, basePath) {
  //...
  let file = new vinyl({
    base: basePath,
    path: target,
    contents: buffer,
  })
  stream.push(file)
  return `<script src="${target}"></script>`
}
```
