### PR TITLE
set also file.base when options.base is provided

### DIFF
--- a/lib/streamManager.js
+++ b/lib/streamManager.js
@@ -106,6 +106,7 @@ var exports = module.exports = (function () {
                     // specify an output path relative to the cwd
                     if (options.base) {
                         newFile.path = path.join(options.base, name);
+                        newFile.base = options.base;
                     }
 
                     // add file to the asset stream

--- a/test/fixtures/templates1/component.html
+++ b/test/fixtures/templates1/component.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+  <!-- build:css css/bundle.css -->
+  <link rel="stylesheet" href="css/four.css">
+  <!-- endbuild -->
+</head>
+</html>

--- a/test/fixtures/templates2/component.html
+++ b/test/fixtures/templates2/component.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+  <!-- build:css /css/combined.css -->
+  <link rel="stylesheet" href="/css/three.css">
+  <!-- endbuild -->
+</head>
+</html>

--- a/test/mock-relative.js
+++ b/test/mock-relative.js
@@ -31,4 +31,31 @@ describe('relative files', function () {
                 done();
             });
     });
+
+    it('should handle relative files when base is set', function (done) {
+        var gulp = require('gulp');
+        var mockGulpDest = require('mock-gulp-dest')(gulp);
+
+        var useref = require('../index');
+
+        gulp.task('relativeBase', function () {
+            return gulp.src(['test/fixtures/templates1/**/*.html', 'test/fixtures/templates2/**/*.html'])
+                .pipe(useref({
+                    searchPath: 'test/fixtures',
+                    base: 'test/fixtures'
+                }))
+                .pipe(gulp.dest('test/dist'));
+        });
+
+        gulp.start('relativeBase')
+            .once('stop', function () {
+                mockGulpDest.basePath().should.equal(path.join(__dirname, 'dist'));
+                mockGulpDest.assertDestContains([
+                    'css/bundle.css',
+                    'css/combined.css'
+                ]);
+
+                done();
+            });
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -730,6 +730,35 @@ describe('useref()', function() {
         stream.end();
     });
 
+    it('should set file.base when asked', function(done) {
+        var a = 0;
+
+        var testFile = getFixture(path.join('templates1', 'component.html'));
+
+        var stream = useref({
+            searchPath: 'fixtures',
+            base: 'fixtures'
+        });
+
+        stream.on('data', function(newFile){
+            should.exist(newFile.contents);
+            if (a === 1) {
+                path.normalize(newFile.path).should.equal(path.normalize('./fixtures/css/bundle.css'));
+                path.normalize(newFile.relative).should.equal(path.normalize('css/bundle.css'))
+            }
+            ++a;
+        });
+
+        stream.once('end', function () {
+            a.should.equal(2);
+            done();
+        });
+
+        stream.write(testFile);
+
+        stream.end();
+    });
+
     it('should support external streams', function(done) {
         var extStream1 = gulp.src('test/fixtures/scripts/that.js')
             .pipe(rename('renamedthat.js'));


### PR DESCRIPTION
This fixes the problem: 
For example, if an html in a subdir references some css-s. You expect the html to end up in a js template (on the root level) and the concatenated css on the root level, not in a subdir.
If you rely on vinyl's basepath, it is currently very hard to do. 

(Well, of course, as a workaround you can pipe, e.g., with through2-spy and set file.base manually.)

In general, this seems like a sane thing to do, anyway.