### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ var gulp = require('gulp'),
     useref = require('gulp-useref'),
     gulpif = require('gulp-if'),
     uglify = require('gulp-uglify'),
-    minifyCss = require('gulp-minify-css');
+    minifyCss = require('gulp-clean-css');
 
 gulp.task('html', function () {
     return gulp.src('app/*.html')


### PR DESCRIPTION
gulp-minify-css is deprecated. Use gulp-clean-css instead.