### PR TITLE
Ignore newline semicolon for css files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,13 +34,14 @@ function addAssetsToStream(paths, files) {
         concat = require('gulp-concat'),
         isRelativeUrl = require('is-relative-url'),
         vfs = require('vinyl-fs'),
+        extend = require('extend'),
         src,
         globs,
         name = paths.name,
         basePath = paths.basePath,
         filepaths = files[name].assets,
         type = paths.type,
-        options = pluginOptions,
+        options = extend({}, pluginOptions),
         gulpConcatOptions = {};
 
     if (!filepaths.length) {

--- a/index.js
+++ b/index.js
@@ -75,7 +75,10 @@ function addAssetsToStream(paths, files) {
     });
 
     // option for newLine in gulp-concat
-    if (options.hasOwnProperty('newLine') || type === 'js') {
+    if (options.hasOwnProperty('newLine')) {
+        if (options.newLine === ';' && type === 'css') {
+            options.newLine = '';
+        }
         gulpConcatOptions.newLine = options.newLine;
     }
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function addAssetsToStream(paths, files) {
         name = paths.name,
         basePath = paths.basePath,
         filepaths = files[name].assets,
+        type = paths.type,
         options = pluginOptions,
         gulpConcatOptions = {};
 
@@ -74,7 +75,7 @@ function addAssetsToStream(paths, files) {
     });
 
     // option for newLine in gulp-concat
-    if (options.hasOwnProperty('newLine')) {
+    if (options.hasOwnProperty('newLine') || type === 'js') {
         gulpConcatOptions.newLine = options.newLine;
     }
 
@@ -121,7 +122,8 @@ function processAssets(file, basePath, data) {
                 basePath: basePath,
                 searchPath: pluginOptions.searchPath,
                 cwd: file.cwd,
-                transformPath: pluginOptions.transformPath
+                transformPath: pluginOptions.transformPath,
+                type: type
             }, files);
         }
     });

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function addAssetsToStream(paths, files) {
     // option for newLine in gulp-concat
     if (options.hasOwnProperty('newLine')) {
         if (options.newLine === ';' && type === 'css') {
-            options.newLine = '';
+            options.newLine = null;
         }
         gulpConcatOptions.newLine = options.newLine;
     }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "event-stream": "^3.3.4",
+    "extend": "^3.0.1",
     "glob": "^7.1.2",
     "gulp-concat": "^2.6.1",
     "gulp-if": "^2.0.2",

--- a/test/test.js
+++ b/test/test.js
@@ -207,7 +207,7 @@ describe('useref()', function() {
             stream = useref({newLine: separator}),
 
             buffer1 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'css', 'one.css'))),
-            buffer2 = new Buffer(''),
+            buffer2 = new Buffer('\n'),
             buffer3 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'css', 'two.css'))),
             bufferFinal = Buffer.concat([buffer1, buffer2, buffer3]),
 

--- a/test/test.js
+++ b/test/test.js
@@ -165,6 +165,72 @@ describe('useref()', function() {
         stream.end();
     });
 
+    it('should concat CSS assets with newLine option', function (done) {
+        var a = 0,
+
+            testFile = getFixture('01.html'),
+            separator = '\r\n',
+
+            stream = useref({newLine: separator}),
+
+            buffer1 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'css', 'one.css'))),
+            buffer2 = new Buffer(separator),
+            buffer3 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'css', 'two.css'))),
+            bufferFinal = Buffer.concat([buffer1, buffer2, buffer3]),
+
+            fileFinal =  new Vinyl({ contents: bufferFinal });
+
+        stream.on('data', function(newFile){
+            if (a === 1) {
+                newFile.path.should.equal(path.normalize('./test/fixtures/css/combined.css'));
+                newFile.contents.toString().should.equal(fileFinal.contents.toString());
+            }
+            ++a;
+        });
+
+        stream.once('end', function () {
+            a.should.equal(2);
+            done();
+        });
+
+        stream.write(testFile);
+
+        stream.end();
+    });
+
+    it('should concat CSS assets but skip newLine option if semicolon', function (done) {
+        var a = 0,
+
+            testFile = getFixture('01.html'),
+            separator = ';',
+
+            stream = useref({newLine: separator}),
+
+            buffer1 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'css', 'one.css'))),
+            buffer2 = new Buffer(''),
+            buffer3 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'css', 'two.css'))),
+            bufferFinal = Buffer.concat([buffer1, buffer2, buffer3]),
+
+            fileFinal =  new Vinyl({ contents: bufferFinal });
+
+        stream.on('data', function(newFile){
+            if (a === 1) {
+                newFile.path.should.equal(path.normalize('./test/fixtures/css/combined.css'));
+                newFile.contents.toString().should.equal(fileFinal.contents.toString());
+            }
+            ++a;
+        });
+
+        stream.once('end', function () {
+            a.should.equal(2);
+            done();
+        });
+
+        stream.write(testFile);
+
+        stream.end();
+    });
+
     it('should skip concatenation and pass CSS assets through with noconcat option', function(done) {
         var a = 0;
 

--- a/test/test.js
+++ b/test/test.js
@@ -319,6 +319,39 @@ describe('useref()', function() {
         stream.end();
     });
 
+    it('should concat JS assets with newLine option if semicolon', function(done) {
+        var a = 0,
+
+            testFile = getFixture('02.html'),
+            separator = ';',
+
+            stream = useref({newLine: separator}),
+
+            buffer1 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'scripts', 'this.js'))),
+            buffer2 = new Buffer(separator),
+            buffer3 = new Buffer(fs.readFileSync(path.join('test', 'fixtures', 'scripts', 'that.js'))),
+            bufferFinal = Buffer.concat([buffer1, buffer2, buffer3]),
+
+            fileFinal =  new Vinyl({ contents: bufferFinal });
+
+        stream.on('data', function(newFile){
+            if (a === 1) {
+                newFile.path.should.equal(path.normalize('./test/fixtures/scripts/combined.js'));
+                newFile.contents.toString().should.equal(fileFinal.contents.toString());
+            }
+            ++a;
+        });
+
+        stream.once('end', function () {
+            a.should.equal(2);
+            done();
+        });
+
+        stream.write(testFile);
+
+        stream.end();
+    });
+
     it('should skip concatenation and pass JS assets through with noconcat option', function(done) {
         var a = 0;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,7 +847,7 @@ extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@^3.0.1, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 


### PR DESCRIPTION
Proposed fix to #241 and #248.

This would ~only apply the newline option when concatenating js files and leave css files alone~ ignore newline semicolon for css files. It turns out css files do not need this option. If they do, then we can come up with another solution. I want to make sure that is needed first though.

