### PR TITLE
Add Feature: Per type newLine separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,19 @@ Skip concatenation and add all assets to the stream instead.
 
 #### options.newLine
 
-Type: `String`  
+Type: `String` or `Object`
 Default: `none`
 
-Add a string that should separate the concatenated files.
+Add a string that should separate the concatenated files. To specify a newLine per type of file processed, provide an object with types as keys and the newLine options as values. For example:
+
+```javascript
+useref({
+    newLine: {
+        js: ';\n',
+        css: '\n'
+    }
+})
+```
 
 #### options.additionalStreams
 

--- a/index.js
+++ b/index.js
@@ -73,7 +73,9 @@ function addAssetsToStream(paths, files) {
 
     // option for newLine in gulp-concat
     if (Object.prototype.hasOwnProperty.call(options, 'newLine')) {
-        if (options.newLine === ';' && type === 'css') {
+        if (typeof options.newLine === 'object') {
+          options.newLine = options.newLine[type];
+        } else if (options.newLine === ';' && type === 'css') {
             options.newLine = null;
         }
         gulpConcatOptions.newLine = options.newLine;

--- a/test/fixtures/13.html
+++ b/test/fixtures/13.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+  <!-- build:js scripts/combined.js -->
+  <script type="text/javascript" src="scripts/this.js"></script>
+  <script type="text/javascript" src="scripts/that.js"></script>
+  <!-- endbuild -->
+  <!-- build:css /css/combined.css -->
+  <link href="/css/one.css" rel="stylesheet">
+  <link href="/css/two.css" rel="stylesheet">
+  <!-- endbuild -->
+</head>
+</html>


### PR DESCRIPTION
Allows providing an object to `options.newLine` to specify a file separator based on the file type. e.g. Joining `js` types with a semicolon and newline, and `css` with just a new line:
``` javascript
useref({
    newLine: {
        js: ';\n',
        css: '\n'
    }
})
```
* Preserves all existing behaviour/assumptions
* Extends fix for #241 
* Maintains #249 
* Implements variant of #248 